### PR TITLE
Fix a typo in the tempAvailable() docs

### DIFF
--- a/src/SparkFunLSM9DS1.h
+++ b/src/SparkFunLSM9DS1.h
@@ -93,7 +93,7 @@ public:
 	//			0 - No new data available
 	uint8_t gyroAvailable();
 	
-	// gyroAvailable() -- Polls the temperature status register to check
+	// tempAvailable() -- Polls the temperature status register to check
 	// if new data is available.
 	// Output:	1 - New data available
 	//			0 - No new data available


### PR DESCRIPTION
It was copy/pasted from gyroAvailable(), and the function name was not updated.
