### PR TITLE
Update SparkFunLSM9DS1.h

### DIFF
--- a/src/SparkFunLSM9DS1.h
+++ b/src/SparkFunLSM9DS1.h
@@ -33,7 +33,7 @@ Distributed as-is; no warranty is given.
 #include "LSM9DS1_Types.h"
 
 #define LSM9DS1_AG_ADDR(sa0)	((sa0) == 0 ? 0x6A : 0x6B)
-#define LSM9DS1_M_ADDR(sa1)		((sa1) == 0 ? 0x1C : 0x1E)
+#define LSM9DS1_M_ADDR(sa1)		((sa1) == 0 ? 0x1C : 0x3C)
 
 enum lsm9ds1_axis {
 	X_AXIS,


### PR DESCRIPTION
According to the Table 20 of the [LSM9DS1 datasheet](http://www.st.com/content/ccc/resource/technical/document/datasheet/1e/3f/2a/d6/25/eb/48/46/DM00103319.pdf/files/DM00103319.pdf/jcr:content/translations/en.DM00103319.pdf), Line 36 in your file [SparkFunLSM9DS1.h](https://github.com/sparkfun/SparkFun_LSM9DS1_Arduino_Library/blob/master/src/SparkFunLSM9DS1.h#L36) should be changed to

`#define LSM9DS1_M_ADDR(sa1) ((sa1) == 0 ? 0x1C : 0x3C)`

This change should propagate through the rest of your documentation.