### PR TITLE
bug fix: temp. sensor value is divided by 256.

### DIFF
--- a/src/SparkFunLSM9DS1.cpp
+++ b/src/SparkFunLSM9DS1.cpp
@@ -573,7 +573,7 @@ void LSM9DS1::readTemp()
 	if ( xgReadBytes(OUT_TEMP_L, temp, 2) == 2 ) // Read 2 bytes, beginning at OUT_TEMP_L
 	{
 		int16_t offset = 25;  // Per datasheet sensor outputs 0 typically @ 25 degrees centigrade
-		temperature = offset + ((((int16_t)temp[1] << 8) | temp[0]) >> 8) ;
+		temperature = offset + ( (((int16_t)temp[1] << 8) | (int16_t)temp[0]) >> 4 );
 	}
 }
 


### PR DESCRIPTION
Temp. Sensor sensitivity is 16 LSB/C we want to divide by 16 which means bitshift by 4 not 8.
Value is 11bit, padded to 16bit with a sign bit, so I guess this is what created the confusion. 