### PR TITLE
Added function definitions to all the example sketches

### DIFF
--- a/examples/LSM9DS1_Basic_I2C/LSM9DS1_Basic_I2C.ino
+++ b/examples/LSM9DS1_Basic_I2C/LSM9DS1_Basic_I2C.ino
@@ -84,6 +84,12 @@ static unsigned long lastPrint = 0; // Keep track of print time
 // http://www.ngdc.noaa.gov/geomag-web/#declination
 #define DECLINATION -8.58 // Declination (degrees) in Boulder, CO.
 
+//Function definitions
+void printGyro();  
+void printAccel(); 
+void printMag();   
+void printAttitude(float ax, float ay, float az, float mx, float my, float mz);
+
 void setup() 
 {
   

--- a/examples/LSM9DS1_Basic_SPI/LSM9DS1_Basic_SPI.ino
+++ b/examples/LSM9DS1_Basic_SPI/LSM9DS1_Basic_SPI.ino
@@ -87,6 +87,12 @@ LSM9DS1 imu;
 // http://www.ngdc.noaa.gov/geomag-web/#declination
 #define DECLINATION -8.58 // Declination (degrees) in Boulder, CO.
 
+//Function definitions
+void printGyro();
+void printAccel();
+void printMag();
+void printAttitude(float ax, float ay, float az, float mx, float my, float mz);
+
 void setup() 
 {
   Serial.begin(115200);

--- a/examples/LSM9DS1_Interrupts/LSM9DS1_Interrupts.ino
+++ b/examples/LSM9DS1_Interrupts/LSM9DS1_Interrupts.ino
@@ -79,6 +79,9 @@ const int RDYM_PIN = 6;  // RDY pin to D6
 // Variable to keep track of when we print sensor readings:
 unsigned long lastPrint = 0;
 
+//Function Definitions
+void printStats();
+
 // configureIMU sets up our LSM9DS1 interface, sensor scales
 // and sample rates.
 uint16_t configureIMU()

--- a/examples/LSM9DS1_Settings/LSM9DS1_Settings.ino
+++ b/examples/LSM9DS1_Settings/LSM9DS1_Settings.ino
@@ -60,6 +60,9 @@ unsigned int tempReadCounter = 0;
 unsigned long lastPrint = 0;
 const unsigned int PRINT_RATE = 500;
 
+//Function definitions
+void printSensorReadings();
+
 void setupDevice()
 {
   // [commInterface] determines whether we'll use I2C or SPI


### PR DESCRIPTION
Hello,
I am using Platformio to write my Arduino sketches. Platformio, by default creates a main.cpp file to have advanced options in the IDE. So I copied the example sketch into my main.cpp and the code was not building. I noticed that there were function declarations after loop() function but the function definitions were missing. So once I added the definitions, the code started compiling. 
Later I discovered that if I compile it as *.ino file, arduino framework does this behind the scenes (link:  https://community.platformio.org/t/order-of-function-declaration/4546/1)
In order to avoid compilation error when compiling it as *.c or *.cpp, I added a function definitions in all the example sketches. Now the code is compatible for *.ino, *.c and *.cpp files. 