### PR TITLE
Added option to use non-default I2C interface

### DIFF
--- a/examples/LSM9DS1_Basic_I2C/LSM9DS1_Basic_I2C.ino
+++ b/examples/LSM9DS1_Basic_I2C/LSM9DS1_Basic_I2C.ino
@@ -1,54 +1,54 @@
 /*****************************************************************
-LSM9DS1_Basic_I2C.ino
-SFE_LSM9DS1 Library Simple Example Code - I2C Interface
-Jim Lindblom @ SparkFun Electronics
-Original Creation Date: April 30, 2015
-https://github.com/sparkfun/LSM9DS1_Breakout
+  LSM9DS1_Basic_I2C.ino
+  SFE_LSM9DS1 Library Simple Example Code - I2C Interface
+  Jim Lindblom @ SparkFun Electronics
+  Original Creation Date: April 30, 2015
+  https://github.com/sparkfun/LSM9DS1_Breakout
 
-The LSM9DS1 is a versatile 9DOF sensor. It has a built-in
-accelerometer, gyroscope, and magnetometer. Very cool! Plus it
-functions over either SPI or I2C.
+  The LSM9DS1 is a versatile 9DOF sensor. It has a built-in
+  accelerometer, gyroscope, and magnetometer. Very cool! Plus it
+  functions over either SPI or I2C.
 
-This Arduino sketch is a demo of the simple side of the
-SFE_LSM9DS1 library. It'll demo the following:
-* How to create a LSM9DS1 object, using a constructor (global
+  This Arduino sketch is a demo of the simple side of the
+  SFE_LSM9DS1 library. It'll demo the following:
+  How to create a LSM9DS1 object, using a constructor (global
   variables section).
-* How to use the begin() function of the LSM9DS1 class.
-* How to read the gyroscope, accelerometer, and magnetometer
-  using the readGryo(), readAccel(), readMag() functions and 
+  How to use the begin() function of the LSM9DS1 class.
+  How to read the gyroscope, accelerometer, and magnetometer
+  using the readGryo(), readAccel(), readMag() functions and
   the gx, gy, gz, ax, ay, az, mx, my, and mz variables.
-* How to calculate actual acceleration, rotation speed, 
-  magnetic field strength using the calcAccel(), calcGyro() 
+  How to calculate actual acceleration, rotation speed,
+  magnetic field strength using the calcAccel(), calcGyro()
   and calcMag() functions.
-* How to use the data from the LSM9DS1 to calculate 
+  How to use the data from the LSM9DS1 to calculate
   orientation and heading.
 
-Hardware setup: This library supports communicating with the
-LSM9DS1 over either I2C or SPI. This example demonstrates how
-to use I2C. The pin-out is as follows:
+  Hardware setup: This library supports communicating with the
+  LSM9DS1 over either I2C or SPI. This example demonstrates how
+  to use I2C. The pin-out is as follows:
 	LSM9DS1 --------- Arduino
 	 SCL ---------- SCL (A5 on older 'Duinos')
 	 SDA ---------- SDA (A4 on older 'Duinos')
 	 VDD ------------- 3.3V
 	 GND ------------- GND
-(CSG, CSXM, SDOG, and SDOXM should all be pulled high. 
-Jumpers on the breakout board will do this for you.)
+  (CSG, CSXM, SDOG, and SDOXM should all be pulled high.
+  Jumpers on the breakout board will do this for you.)
 
-The LSM9DS1 has a maximum voltage of 3.6V. Make sure you power it
-off the 3.3V rail! I2C pins are open-drain, so you'll be 
-(mostly) safe connecting the LSM9DS1's SCL and SDA pins 
-directly to the Arduino.
+  The LSM9DS1 has a maximum voltage of 3.6V. Make sure you power it
+  off the 3.3V rail! I2C pins are open-drain, so you'll be
+  (mostly) safe connecting the LSM9DS1's SCL and SDA pins
+  directly to the Arduino.
 
-Development environment specifics:
+  Development environment specifics:
 	IDE: Arduino 1.6.3
 	Hardware Platform: SparkFun Redboard
 	LSM9DS1 Breakout Version: 1.0
 
-This code is beerware. If you see me (or any other SparkFun 
-employee) at the local, and you've found our code helpful, 
-please buy us a round!
+  This code is beerware. If you see me (or any other SparkFun
+  employee) at the local, and you've found our code helpful,
+  please buy us a round!
 
-Distributed as-is; no warranty is given.
+  Distributed as-is; no warranty is given.
 *****************************************************************/
 // The SFE_LSM9DS1 library requires both Wire and SPI be
 // included BEFORE including the 9DS1 library.
@@ -67,8 +67,8 @@ LSM9DS1 imu;
 // Example I2C Setup //
 ///////////////////////
 // SDO_XM and SDO_G are both pulled high, so our addresses are:
-#define LSM9DS1_M	0x1E // Would be 0x1C if SDO_M is LOW
-#define LSM9DS1_AG	0x6B // Would be 0x6A if SDO_AG is LOW
+// #define LSM9DS1_M	0x1E // Would be 0x1C if SDO_M is LOW
+// #define LSM9DS1_AG	0x6B // Would be 0x6A if SDO_AG is LOW
 
 ////////////////////////////
 // Sketch Output Settings //
@@ -78,42 +78,33 @@ LSM9DS1 imu;
 #define PRINT_SPEED 250 // 250 ms between prints
 static unsigned long lastPrint = 0; // Keep track of print time
 
-// Earth's magnetic field varies by location. Add or subtract 
-// a declination to get a more accurate heading. Calculate 
+// Earth's magnetic field varies by location. Add or subtract
+// a declination to get a more accurate heading. Calculate
 // your's here:
 // http://www.ngdc.noaa.gov/geomag-web/#declination
 #define DECLINATION -8.58 // Declination (degrees) in Boulder, CO.
 
 //Function definitions
-void printGyro();  
-void printAccel(); 
-void printMag();   
+void printGyro();
+void printAccel();
+void printMag();
 void printAttitude(float ax, float ay, float az, float mx, float my, float mz);
 
-void setup() 
+void setup()
 {
-  
   Serial.begin(115200);
-  
-  // Before initializing the IMU, there are a few settings
-  // we may need to adjust. Use the settings struct to set
-  // the device's communication mode and addresses:
-  imu.settings.device.commInterface = IMU_MODE_I2C;
-  imu.settings.device.mAddress = LSM9DS1_M;
-  imu.settings.device.agAddress = LSM9DS1_AG;
-  // The above lines will only take effect AFTER calling
-  // imu.begin(), which verifies communication with the IMU
-  // and turns it on.
-  if (!imu.begin())
+
+  Wire.begin();
+
+  if (!imu.begin()) // with no arguments, this uses default addresses (AG:0x6B, M:0x1E) and i2c port (Wire).
   {
     Serial.println("Failed to communicate with LSM9DS1.");
     Serial.println("Double-check wiring.");
     Serial.println("Default settings in this sketch will " \
-                  "work for an out of the box LSM9DS1 " \
-                  "Breakout, but may need to be modified " \
-                  "if the board jumpers are.");
-    while (1)
-      ;
+                   "work for an out of the box LSM9DS1 " \
+                   "Breakout, but may need to be modified " \
+                   "if the board jumpers are.");
+    while (1);
   }
 }
 
@@ -141,7 +132,7 @@ void loop()
     // mx, my, and mz variables with the most current data.
     imu.readMag();
   }
-  
+
   if ((lastPrint + PRINT_SPEED) < millis())
   {
     printGyro();  // Print "G: gx, gy, gz"
@@ -151,10 +142,10 @@ void loop()
     // Call print attitude. The LSM9DS1's mag x and y
     // axes are opposite to the accelerometer, so my, mx are
     // substituted for each other.
-    printAttitude(imu.ax, imu.ay, imu.az, 
-                 -imu.my, -imu.mx, imu.mz);
+    printAttitude(imu.ax, imu.ay, imu.az,
+                  -imu.my, -imu.mx, imu.mz);
     Serial.println();
-    
+
     lastPrint = millis(); // Update lastPrint time
   }
 }
@@ -184,7 +175,7 @@ void printGyro()
 }
 
 void printAccel()
-{  
+{
   // Now we can use the ax, ay, and az variables as we please.
   // Either print them as raw ADC values, or calculated in g's.
   Serial.print("A: ");
@@ -198,7 +189,7 @@ void printAccel()
   Serial.print(", ");
   Serial.print(imu.calcAccel(imu.az), 2);
   Serial.println(" g");
-#elif defined PRINT_RAW 
+#elif defined PRINT_RAW
   Serial.print(imu.ax);
   Serial.print(", ");
   Serial.print(imu.ay);
@@ -209,7 +200,7 @@ void printAccel()
 }
 
 void printMag()
-{  
+{
   // Now we can use the mx, my, and mz variables as we please.
   // Either print them as raw ADC values, or calculated in Gauss.
   Serial.print("M: ");
@@ -241,23 +232,23 @@ void printAttitude(float ax, float ay, float az, float mx, float my, float mz)
 {
   float roll = atan2(ay, az);
   float pitch = atan2(-ax, sqrt(ay * ay + az * az));
-  
+
   float heading;
   if (my == 0)
     heading = (mx < 0) ? PI : 0;
   else
     heading = atan2(mx, my);
-    
+
   heading -= DECLINATION * PI / 180;
-  
+
   if (heading > PI) heading -= (2 * PI);
   else if (heading < -PI) heading += (2 * PI);
-  
+
   // Convert everything from radians to degrees:
   heading *= 180.0 / PI;
   pitch *= 180.0 / PI;
   roll  *= 180.0 / PI;
-  
+
   Serial.print("Pitch, Roll: ");
   Serial.print(pitch, 2);
   Serial.print(", ");

--- a/examples/LSM9DS1_Basic_SPI/LSM9DS1_Basic_SPI.ino
+++ b/examples/LSM9DS1_Basic_SPI/LSM9DS1_Basic_SPI.ino
@@ -96,17 +96,10 @@ void printAttitude(float ax, float ay, float az, float mx, float my, float mz);
 void setup() 
 {
   Serial.begin(115200);
-  
-  // Before initializing the IMU, there are a few settings
-  // we may need to adjust. Use the settings struct to set
-  // the device's communication mode and addresses:
-  imu.settings.device.commInterface = IMU_MODE_SPI;
-  imu.settings.device.mAddress = LSM9DS1_M_CS;
-  imu.settings.device.agAddress = LSM9DS1_AG_CS;
-  // The above lines will only take effect AFTER calling
-  // imu.begin(), which verifies communication with the IMU
+ 
+  // imu.beginSPI(), which verifies communication with the IMU
   // and turns it on.
-  if (!imu.begin())
+  if (!imu.beginSPI(LSM9DS1_AG_CS, LSM9DS1_M_CS)) // note, we need to sent this our CS pins (defined above)
   {
     Serial.println("Failed to communicate with LSM9DS1.");
     Serial.println("Double-check wiring.");

--- a/examples/LSM9DS1_Interrupts/LSM9DS1_Interrupts.ino
+++ b/examples/LSM9DS1_Interrupts/LSM9DS1_Interrupts.ino
@@ -40,6 +40,7 @@ to use I2C. The pin-out is as follows:
    INT2 ------------- D4
    INT1 ------------- D3
    INTM ------------- D5
+   RDY -------------- D6
 (CSG, CSXM, SDOG, and SDOXM should all be pulled high. 
 Jumpers on the breakout board will do this for you.)
 
@@ -86,11 +87,6 @@ void printStats();
 // and sample rates.
 uint16_t configureIMU()
 {
-  // Set up Device Mode (I2C) and I2C addresses:
-  imu.settings.device.commInterface = IMU_MODE_I2C;
-  imu.settings.device.agAddress = LSM9DS1_AG_ADDR(1);
-  imu.settings.device.mAddress = LSM9DS1_M_ADDR(1);
-
   // gyro.latchInterrupt controls the latching of the
   // gyro and accelerometer interrupts (INT1 and INT2).
   // false = no latching
@@ -106,10 +102,10 @@ uint16_t configureIMU()
   imu.settings.mag.scale = 4;
   // Set magnetometer sample rate to 0.625 Hz
   imu.settings.mag.sampleRate = 0;
-
+  
   // Call imu.begin() to initialize the sensor and instill
   // it with our new settings.
-  return imu.begin();
+  return imu.begin(LSM9DS1_AG_ADDR(1), LSM9DS1_M_ADDR(1), Wire); // set addresses and wire port
 }
 
 void configureLSM9DS1Interrupts()
@@ -193,6 +189,8 @@ void setup()
   // The magnetometer DRDY pin (RDY) is not configurable.
   // It is active high and always turned on.
   pinMode(RDYM_PIN, INPUT);
+
+  Wire.begin();
 
   // Turn on the IMU with configureIMU() (defined above)
   // check the return status of imu.begin() to make sure
@@ -312,4 +310,3 @@ void printStats()
   Serial.print(imu.my); Serial.print(", ");
   Serial.println(imu.mz);
 }
-

--- a/examples/LSM9DS1_Settings/LSM9DS1_Settings.ino
+++ b/examples/LSM9DS1_Settings/LSM9DS1_Settings.ino
@@ -49,6 +49,10 @@ Distributed as-is; no warranty is given.
 
 LSM9DS1 imu;  // Create an LSM9DS1 object
 
+// SDO_XM and SDO_G are both pulled high, so our addresses are:
+#define LSM9DS1_M  0x1E // Would be 0x1C if SDO_M is LOW
+#define LSM9DS1_AG 0x6B // Would be 0x6A if SDO_AG is LOW
+
 // Global variables to keep track of update rates
 unsigned long startTime;
 unsigned int accelReadCounter = 0;
@@ -62,20 +66,6 @@ const unsigned int PRINT_RATE = 500;
 
 //Function definitions
 void printSensorReadings();
-
-void setupDevice()
-{
-  // [commInterface] determines whether we'll use I2C or SPI
-  // to communicate with the LSM9DS1.
-  // Use either IMU_MODE_I2C or IMU_MODE_SPI
-  imu.settings.device.commInterface = IMU_MODE_I2C;
-  // [mAddress] sets the I2C address or SPI CS pin of the
-  // LSM9DS1's magnetometer.
-  imu.settings.device.mAddress = 0x1E; // Use I2C addres 0x1E
-  // [agAddress] sets the I2C address or SPI CS pin of the
-  // LSM9DS1's accelerometer/gyroscope.
-  imu.settings.device.agAddress = 0x6B; // I2C address 0x6B
-}
 
 void setupGyro()
 {
@@ -192,18 +182,19 @@ void setupTemperature()
 
 uint16_t initLSM9DS1()
 {
-  setupDevice(); // Setup general device parameters
   setupGyro(); // Set up gyroscope parameters
   setupAccel(); // Set up accelerometer parameters
   setupMag(); // Set up magnetometer parameters
   setupTemperature(); // Set up temp sensor parameter
   
-  return imu.begin();
+  return imu.begin(LSM9DS1_AG, LSM9DS1_M, Wire); // for SPI use beginSPI()
 }
 
 void setup() 
 {
   Serial.begin(115200);
+
+  Wire.begin();
   
   Serial.println("Initializing the LSM9DS1");
   uint16_t status = initLSM9DS1();
@@ -300,4 +291,3 @@ void printSensorReadings()
   Serial.println(" Hz");  
   Serial.println();
 }
-

--- a/keywords.txt
+++ b/keywords.txt
@@ -28,6 +28,7 @@ gBiasRaw	KEYWORD2
 aBiasRaw	KEYWORD2
 mBiasRaw	KEYWORD2
 begin	KEYWORD2
+beginSPI	KEYWORD2
 calibrate	KEYWORD2
 calibrateMag	KEYWORD2
 magOffset	KEYWORD2

--- a/src/LSM9DS1_Types.h
+++ b/src/LSM9DS1_Types.h
@@ -22,6 +22,7 @@ Distributed as-is; no warranty is given.
 #define __LSM9DS1_Types_H__
 
 #include "LSM9DS1_Registers.h"
+#include <Wire.h>
 
 // The LSM9DS1 functions over both I2C or SPI. This library supports both.
 // But the interface mode used must be sent to the LSM9DS1 constructor. Use
@@ -199,6 +200,7 @@ struct deviceSettings
 	uint8_t commInterface; // Can be I2C, SPI 4-wire or SPI 3-wire
 	uint8_t agAddress;	 // I2C address or SPI CS pin
 	uint8_t mAddress;	  // I2C address or SPI CS pin
+  TwoWire* i2c;    // pointer to an instance of I2C interface
 };
 
 struct accelSettings

--- a/src/SparkFunLSM9DS1.cpp
+++ b/src/SparkFunLSM9DS1.cpp
@@ -50,21 +50,10 @@ Distributed as-is; no warranty is given.
 
 LSM9DS1::LSM9DS1()
 {
-	init(IMU_MODE_I2C, LSM9DS1_AG_ADDR(1), LSM9DS1_M_ADDR(1));
 }
 
-LSM9DS1::LSM9DS1(interface_mode interface, uint8_t xgAddr, uint8_t mAddr)
+void LSM9DS1::init()
 {
-	init(interface, xgAddr, mAddr);
-}
-
-void LSM9DS1::init(interface_mode interface, uint8_t xgAddr, uint8_t mAddr)
-{
-	settings.device.commInterface = interface;
-	settings.device.agAddress = xgAddr;
-	settings.device.mAddress = mAddr;
-  settings.device.i2c = &Wire;
-
 	settings.gyro.enabled = true;
 	settings.gyro.enableX = true;
 	settings.gyro.enableY = true;
@@ -151,11 +140,65 @@ void LSM9DS1::init(interface_mode interface, uint8_t xgAddr, uint8_t mAddr)
 }
 
 
-uint16_t LSM9DS1::begin()
+uint16_t LSM9DS1::begin(uint8_t agAddress, uint8_t mAddress, TwoWire &wirePort)
 {
+	// Set device settings, they are used in many other places
+	settings.device.commInterface = IMU_MODE_I2C;
+	settings.device.agAddress = agAddress;
+	settings.device.mAddress = mAddress;
+	settings.device.i2c = &wirePort;
+	
 	//! Todo: don't use _xgAddress or _mAddress, duplicating memory
 	_xgAddress = settings.device.agAddress;
 	_mAddress = settings.device.mAddress;
+	
+	init();
+	
+	constrainScales();
+	// Once we have the scale values, we can calculate the resolution
+	// of each sensor. That's what these functions are for. One for each sensor
+	calcgRes(); // Calculate DPS / ADC tick, stored in gRes variable
+	calcmRes(); // Calculate Gs / ADC tick, stored in mRes variable
+	calcaRes(); // Calculate g / ADC tick, stored in aRes variable
+	
+	// We expect caller to begin their I2C port, with the speed of their choice external to the library
+	// But if they forget, we could start the hardware here.
+	// settings.device.i2c->begin();	// Initialize I2C library
+		
+	// To verify communication, we can read from the WHO_AM_I register of
+	// each device. Store those in a variable so we can return them.
+	uint8_t mTest = mReadByte(WHO_AM_I_M);		// Read the gyro WHO_AM_I
+	uint8_t xgTest = xgReadByte(WHO_AM_I_XG);	// Read the accel/mag WHO_AM_I
+	uint16_t whoAmICombined = (xgTest << 8) | mTest;
+	
+	if (whoAmICombined != ((WHO_AM_I_AG_RSP << 8) | WHO_AM_I_M_RSP))
+		return 0;
+	
+	// Gyro initialization stuff:
+	initGyro();	// This will "turn on" the gyro. Setting up interrupts, etc.
+	
+	// Accelerometer initialization stuff:
+	initAccel(); // "Turn on" all axes of the accel. Set up interrupts, etc.
+	
+	// Magnetometer initialization stuff:
+	initMag(); // "Turn on" all axes of the mag. Set up interrupts, etc.
+
+	// Once everything is initialized, return the WHO_AM_I registers we read:
+	return whoAmICombined;
+}
+
+uint16_t LSM9DS1::beginSPI(uint8_t ag_CS_pin, uint8_t m_CS_pin)
+{
+	// Set device settings, they are used in many other places
+	settings.device.commInterface = IMU_MODE_SPI;
+	settings.device.agAddress = ag_CS_pin;
+	settings.device.mAddress = m_CS_pin;	
+	
+	//! Todo: don't use _xgAddress or _mAddress, duplicating memory
+	_xgAddress = settings.device.agAddress;
+	_mAddress = settings.device.mAddress;
+	
+	init();
 	
 	constrainScales();
 	// Once we have the scale values, we can calculate the resolution
@@ -165,10 +208,7 @@ uint16_t LSM9DS1::begin()
 	calcaRes(); // Calculate g / ADC tick, stored in aRes variable
 	
 	// Now, initialize our hardware interface.
-	if (settings.device.commInterface == IMU_MODE_I2C)	// If we're using I2C
-		initI2C();	// Initialize I2C
-	else if (settings.device.commInterface == IMU_MODE_SPI) 	// else, if we're using SPI
-		initSPI();	// Initialize SPI
+	initSPI();	// Initialize SPI
 		
 	// To verify communication, we can read from the WHO_AM_I register of
 	// each device. Store those in a variable so we can return them.
@@ -1146,11 +1186,6 @@ uint8_t LSM9DS1::SPIreadBytes(uint8_t csPin, uint8_t subAddress,
 	digitalWrite(csPin, HIGH); // Close communication
 	
 	return count;
-}
-
-void LSM9DS1::initI2C()
-{
-	settings.device.i2c->begin();	// Initialize I2C library
 }
 
 // Wire.h read and write protocols

--- a/src/SparkFunLSM9DS1.h
+++ b/src/SparkFunLSM9DS1.h
@@ -69,13 +69,21 @@ public:
 	// 				If IMU_MODE_SPI, this is the chip select pin of the gyro (CS_AG)
 	//	- mAddr = If IMU_MODE_I2C, this is the I2C address of the magnetometer.
 	//				If IMU_MODE_SPI, this is the cs pin of the magnetometer (CS_M)
-	LSM9DS1(interface_mode interface, uint8_t xgAddr, uint8_t mAddr);
 	LSM9DS1();
 		
-	// begin() -- Initialize the gyro, accelerometer, and magnetometer.
+	// begin() and beginSPI() -- Initialize the gyro, accelerometer, and magnetometer.
 	// This will set up the scale and output rate of each sensor. The values set
 	// in the IMUSettings struct will take effect after calling this function.
-	uint16_t begin();
+	// INPUTS:
+	// - agAddress - Sets either the I2C address of the accel/gyro or SPI chip 
+	//   select pin connected to the CS_XG pin.
+	// - mAddress - Sets either the I2C address of the magnetometer or SPI chip 
+	//   select pin connected to the CS_M pin.
+	// - i2C port (Note, only on "begin()" funtion, for use with I2C com interface)
+	//   defaults to Wire, but if hardware supports it, can use other TwoWire ports.
+	//   **For SPI use "beginSPI()", and only send first two address arguments.
+	uint16_t begin(uint8_t agAddress = LSM9DS1_AG_ADDR(1), uint8_t mAddress = LSM9DS1_M_ADDR(1), TwoWire &wirePort = Wire); //By default use the default I2C addres, and use Wire port
+	uint16_t beginSPI(uint8_t ag_CS_pin, uint8_t m_CS_pin);
 	
 	void calibrate(bool autoCalc = true);
 	void calibrateMag(bool loadIn = true);
@@ -345,12 +353,8 @@ protected:
 	bool _autoCalc;
 	
 	// init() -- Sets up gyro, accel, and mag settings to default.
-	// - interface - Sets the interface mode (IMU_MODE_I2C or IMU_MODE_SPI)
-	// - xgAddr - Sets either the I2C address of the accel/gyro or SPI chip 
-	//   select pin connected to the CS_XG pin.
-	// - mAddr - Sets either the I2C address of the magnetometer or SPI chip 
-	//   select pin connected to the CS_M pin.
-	void init(interface_mode interface, uint8_t xgAddr, uint8_t mAddr);
+	// to set com interface and/or addresses see begin() and beginSPI().
+	void init();
 	
 	// initGyro() -- Sets up the gyroscope to begin reading.
 	// This function steps through all five gyroscope control registers.
@@ -491,9 +495,6 @@ protected:
 	///////////////////
 	// I2C Functions //
 	///////////////////
-	// initI2C() -- Initialize the I2C hardware.
-	// This function will setup all I2C pins and related hardware.
-	void initI2C();
 	
 	// I2CwriteByte() -- Write a byte out of I2C to a register in the device
 	// Input:


### PR DESCRIPTION
Arduino cores offer more than one I2C interface (e.g. STM32). I added the option to use any `TwoWire` instance as the communication interface - it's set to `Wire` by default, so existing code shouldn't be affected.