### PR TITLE
Fix readTemperature function

### DIFF
--- a/src/SparkFunLSM9DS1.cpp
+++ b/src/SparkFunLSM9DS1.cpp
@@ -607,13 +607,26 @@ int16_t LSM9DS1::readMag(lsm9ds1_axis axis)
 	return 0;
 }
 
+typedef union
+{
+	struct
+	{
+		int16_t data :12;
+		int16_t Reserved :4;
+	};
+	int16_t word;
+} int12_t;
+
 void LSM9DS1::readTemp()
 {
 	uint8_t temp[2]; // We'll read two bytes from the temperature sensor into temp	
 	if ( xgReadBytes(OUT_TEMP_L, temp, 2) == 2 ) // Read 2 bytes, beginning at OUT_TEMP_L
 	{
+		int12_t degree;
+		degree.word = ( ( int16_t )temp[ 1 ] << 8 ) | ( int16_t ) temp[ 0 ];
+		
 		int16_t offset = 25;  // Per datasheet sensor outputs 0 typically @ 25 degrees centigrade
-		temperature = offset + ((((int16_t)temp[1] << 8) | temp[0]) >> 8) ;
+		temperature = offset + degree.data / 16;
 	}
 }
 


### PR DESCRIPTION
Temperature values are obtained using only 12 bits, as shown on page 49 of the datasheet, reflecting a one degree change per 16 LSB. And this could solve #21.

https://www.st.com/resource/en/datasheet/lsm9ds1.pdf
- 2.3 Temperature sensor characteristics
- 7.17 OUT_TEMP_L (15h), OUT_TEMP_H (16h)

