### PR TITLE
Fix for loss of user-defined settings when calling begin()

### DIFF
--- a/src/SparkFunLSM9DS1.cpp
+++ b/src/SparkFunLSM9DS1.cpp
@@ -50,6 +50,7 @@ Distributed as-is; no warranty is given.
 
 LSM9DS1::LSM9DS1()
 {
+	init(); //Initialise settings
 }
 
 void LSM9DS1::init()
@@ -152,8 +153,6 @@ uint16_t LSM9DS1::begin(uint8_t agAddress, uint8_t mAddress, TwoWire &wirePort)
 	_xgAddress = settings.device.agAddress;
 	_mAddress = settings.device.mAddress;
 	
-	init();
-	
 	constrainScales();
 	// Once we have the scale values, we can calculate the resolution
 	// of each sensor. That's what these functions are for. One for each sensor
@@ -197,8 +196,6 @@ uint16_t LSM9DS1::beginSPI(uint8_t ag_CS_pin, uint8_t m_CS_pin)
 	//! Todo: don't use _xgAddress or _mAddress, duplicating memory
 	_xgAddress = settings.device.agAddress;
 	_mAddress = settings.device.mAddress;
-	
-	init();
 	
 	constrainScales();
 	// Once we have the scale values, we can calculate the resolution

--- a/src/SparkFunLSM9DS1.h
+++ b/src/SparkFunLSM9DS1.h
@@ -71,9 +71,8 @@ public:
 	//				If IMU_MODE_SPI, this is the cs pin of the magnetometer (CS_M)
 	LSM9DS1();
 		
-	// begin() and beginSPI() -- Initialize the gyro, accelerometer, and magnetometer.
-	// This will set up the scale and output rate of each sensor. The values set
-	// in the IMUSettings struct will take effect after calling this function.
+	// begin() and beginSPI() -- The values set in the IMUSettings struct will take
+	// effect after calling this function.
 	// INPUTS:
 	// - agAddress - Sets either the I2C address of the accel/gyro or SPI chip 
 	//   select pin connected to the CS_XG pin.


### PR DESCRIPTION
Moved initilisation to constructor so that user defined settings are preserved when calling begin()

Made to address #27 